### PR TITLE
set selenium default drivers

### DIFF
--- a/lib/config/get-defaults.js
+++ b/lib/config/get-defaults.js
@@ -25,9 +25,8 @@ function getDefaults () {
       hub: 'http://localhost:4444/wd/hub/status',
 
       // https://github.com/vvo/selenium-standalone
-      standalone: {
-        // see defaults at https://github.com/vvo/selenium-standalone/blob/master/lib/default-config.js
-      },
+      // see defaults at https://github.com/vvo/selenium-standalone/blob/master/lib/default-config.js
+      standalone: require('selenium-standalone/lib/default-config'),
 
       // will be merged into webdriver if run against local selenium
       webdriver: {}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "request": "^2.78.0",
     "sauce-connect-launcher": "^1.0.0",
     "saucelabs": "^1.3.0",
-    "selenium-standalone": "^6.0.0",
+    "selenium-standalone": "6.0.1",
     "username": "^2.2.2",
     "webdriverio": "^4.4.0"
   },


### PR DESCRIPTION
looks like this broke in some previous version of selenium-standalone. To prevent this from happening again, I fixed the version number and load defaults now directly from the `selenium-standalone` package